### PR TITLE
修正单词拼写错误

### DIFF
--- a/toolchain/editor-and-ide.md
+++ b/toolchain/editor-and-ide.md
@@ -40,7 +40,7 @@ settings.json
 核心拓展：
 
 - VS Live Share
-- Visual Studio Intelicode
+- Visual Studio Intellicode
 - Remote Development
 - Code Runner
 


### PR DESCRIPTION
Intelicode 应为 Intellicode