### PR TITLE
fix: add prefix for features of the material theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ theme:
     text: 'Noto Sans SC'
     code: 'Source Code Pro'
   features:
-    - instant
-    - tabs
+    - navigation.instant
+    - navigation.tabs
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
The usages have been changed. For more information, plase refer to 'https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/'.